### PR TITLE
Add login workflow with session-based authentication

### DIFF
--- a/LabCenterIMS.html
+++ b/LabCenterIMS.html
@@ -71,6 +71,102 @@
         overflow: hidden;
       }
 
+      body:not(.authenticated) > :not(#login-screen):not(script) {
+        display: none;
+      }
+
+      #login-screen {
+        position: fixed;
+        inset: 0;
+        background: var(--surface);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 24px;
+        overflow: auto;
+      }
+
+      body.authenticated #login-screen {
+        display: none;
+      }
+
+      .login-panel {
+        width: min(420px, 100%);
+        background: var(--bg);
+        border-radius: var(--radius);
+        border: 1px solid var(--line);
+        box-shadow: var(--shadow);
+        padding: 32px;
+        display: grid;
+        gap: 18px;
+      }
+
+      .login-header h1 {
+        margin: 0 0 6px;
+        font-size: 22px;
+      }
+
+      .login-header p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .login-field {
+        display: grid;
+        gap: 6px;
+      }
+
+      .login-field label {
+        font-weight: 600;
+        font-size: 14px;
+      }
+
+      .login-field input {
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        font-size: 15px;
+      }
+
+      .login-field input:focus-visible {
+        outline: 2px solid var(--focus);
+        outline-offset: 2px;
+      }
+
+      .login-actions {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .login-error {
+        color: var(--overdue-fg);
+        font-size: 14px;
+        min-height: 18px;
+      }
+
+      .btn-ghost {
+        background: transparent;
+        border-color: transparent;
+        color: var(--muted);
+      }
+
+      .btn-ghost:hover {
+        background: rgba(17, 24, 39, 0.04);
+      }
+
+      .user-chip {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-size: 13px;
+        color: var(--muted);
+      }
+
       /* Header (fixed) */
       header {
         display: flex;
@@ -687,12 +783,56 @@
     </style>
   </head>
   <body>
+    <div id="login-screen">
+      <form class="login-panel" id="login-form" autocomplete="off">
+        <div class="login-header">
+          <h1>Sign in to Lab Center IMS</h1>
+          <p>
+            Enter your lab username and password to continue. Unless it has been
+            changed, the default password is <strong>password123</strong>.
+          </p>
+        </div>
+        <div class="login-field">
+          <label for="login-username">Username</label>
+          <input
+            id="login-username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+          />
+        </div>
+        <div class="login-field">
+          <label for="login-password">Password</label>
+          <input
+            id="login-password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+          />
+        </div>
+        <div class="login-error" id="login-error" role="alert"></div>
+        <div class="login-actions">
+          <button type="submit" class="btn primary" id="login-submit">
+            Sign in
+          </button>
+          <button type="button" class="btn btn-ghost" id="login-reset">
+            Reset
+          </button>
+        </div>
+      </form>
+    </div>
     <header>
       <div class="brand">
         <img class="logo" src="action_mark_green.avif" alt="Lab Center Logo" />
         <div class="title">Cincinnati State Lab Center — IMS</div>
       </div>
       <div class="hdr-right">
+        <div class="user-chip" id="current-user-display" aria-live="polite"></div>
+        <button class="btn btn-ghost" id="btn-logout" type="button">
+          Sign out
+        </button>
         <button class="btn" data-open="dlg-help">
           <span>Quick Help</span>
         </button>
@@ -1805,12 +1945,36 @@
       // Class: Web Dev / JS
       // Abstract: Client interactions for Lab Center IMS interface.
       // -----------------------------------------------------------------------------
-      document.addEventListener("DOMContentLoaded", () => {
+      document.addEventListener("DOMContentLoaded", async () => {
         "use strict";
 
         // ====== CONFIG ======
         const USE_BACKEND = true; // flip to true when your API is running
         const API_BASE = "/api";
+        const SESSION_STORAGE_KEY = "labcenter.sessionToken";
+        const SESSION_MESSAGE_KEY = "labcenter.authMessage";
+        const SESSION_IDLE_LIMIT_MS = 15 * 60 * 1000;
+
+        let m_strSessionToken = null;
+        let m_objCurrentUser = null;
+        let m_idIdleTimer = null;
+        let m_boolHasBootstrapped = false;
+        let m_boolAuthReloadPending = false;
+        let m_strQueuedAuthMessage = window.sessionStorage.getItem(
+          SESSION_MESSAGE_KEY,
+        );
+        if (m_strQueuedAuthMessage) {
+          window.sessionStorage.removeItem(SESSION_MESSAGE_KEY);
+        }
+
+        const elLoginForm = document.getElementById("login-form");
+        const elLoginUsername = document.getElementById("login-username");
+        const elLoginPassword = document.getElementById("login-password");
+        const elLoginError = document.getElementById("login-error");
+        const elLoginSubmit = document.getElementById("login-submit");
+        const elLoginReset = document.getElementById("login-reset");
+        const elLogoutButton = document.getElementById("btn-logout");
+        const elUserDisplay = document.getElementById("current-user-display");
 
         // ====== UTIL ======
         const fnSelectElement = (sel, root = document) =>
@@ -1819,6 +1983,207 @@
           Array.from(root.querySelectorAll(sel));
         const fnSetBusyState = (btn, busy = true) =>
           btn.setAttribute("aria-busy", busy ? "true" : "false");
+
+        function fnUpdateUserDisplay() {
+          if (!elUserDisplay) return;
+          if (!m_objCurrentUser) {
+            elUserDisplay.textContent = "";
+            elUserDisplay.title = "";
+            return;
+          }
+          const name =
+            m_objCurrentUser.displayName ||
+            m_objCurrentUser.username ||
+            "Signed in";
+          elUserDisplay.textContent = name;
+          elUserDisplay.title = m_objCurrentUser.roleLabel
+            ? `${name} — ${m_objCurrentUser.roleLabel}`
+            : name;
+        }
+
+        function fnClearIdleTimer() {
+          if (m_idIdleTimer) {
+            window.clearTimeout(m_idIdleTimer);
+            m_idIdleTimer = null;
+          }
+        }
+
+        function fnResetIdleTimer() {
+          if (!m_strSessionToken) return;
+          fnClearIdleTimer();
+          m_idIdleTimer = window.setTimeout(() => {
+            fnLogout({ idle: true });
+          }, SESSION_IDLE_LIMIT_MS);
+        }
+
+        function fnApplySession(token, user, { persist = true } = {}) {
+          m_strSessionToken = token || null;
+          m_objCurrentUser = user || null;
+          if (persist) {
+            if (m_strSessionToken) {
+              window.localStorage.setItem(
+                SESSION_STORAGE_KEY,
+                m_strSessionToken,
+              );
+            } else {
+              window.localStorage.removeItem(SESSION_STORAGE_KEY);
+            }
+          }
+          fnUpdateUserDisplay();
+        }
+
+        function fnClearSession() {
+          fnApplySession(null, null);
+          fnClearIdleTimer();
+          document.body.classList.remove("authenticated");
+        }
+
+        function fnShowLogin(message) {
+          fnClearSession();
+          if (elLoginError) {
+            elLoginError.textContent =
+              message || m_strQueuedAuthMessage || "";
+          }
+          m_strQueuedAuthMessage = "";
+          window.requestAnimationFrame(() => {
+            elLoginUsername?.focus();
+          });
+        }
+
+        async function fnRestoreSession() {
+          const stored = window.localStorage.getItem(SESSION_STORAGE_KEY);
+          if (!stored) {
+            return false;
+          }
+          m_strSessionToken = stored;
+          try {
+            const res = await fetch(`${API_BASE}/session`, {
+              method: "GET",
+              headers: { Authorization: `Bearer ${stored}` },
+            });
+            if (!res.ok) throw new Error("Not authenticated");
+            const payload = await res.json();
+            if (!payload?.user) throw new Error("Invalid session");
+            fnApplySession(stored, payload.user, { persist: false });
+            return true;
+          } catch (err) {
+            window.localStorage.removeItem(SESSION_STORAGE_KEY);
+            fnApplySession(null, null, { persist: false });
+            return false;
+          }
+        }
+
+        async function fnHandleUnauthorized() {
+          if (m_boolAuthReloadPending) return;
+          m_boolAuthReloadPending = true;
+          window.localStorage.removeItem(SESSION_STORAGE_KEY);
+          window.sessionStorage.setItem(
+            SESSION_MESSAGE_KEY,
+            "Your session has expired. Please sign in again.",
+          );
+          window.location.reload();
+        }
+
+        async function fnLogout({ idle = false } = {}) {
+          if (!m_strSessionToken) {
+            fnShowLogin();
+            return;
+          }
+          try {
+            await fetch(`${API_BASE}/logout`, {
+              method: "POST",
+              headers: { Authorization: `Bearer ${m_strSessionToken}` },
+            });
+          } catch (err) {
+            // ignore network issues on logout
+          } finally {
+            window.localStorage.removeItem(SESSION_STORAGE_KEY);
+            if (idle) {
+              window.sessionStorage.setItem(
+                SESSION_MESSAGE_KEY,
+                "Signed out after 15 minutes of inactivity.",
+              );
+            }
+            window.location.reload();
+          }
+        }
+
+        if (elLoginForm) {
+          elLoginForm.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            const username = elLoginUsername?.value.trim().toLowerCase();
+            const password = elLoginPassword?.value.trim();
+            if (!username || !password) {
+              if (elLoginError) {
+                elLoginError.textContent =
+                  "Username and password are required.";
+              }
+              return;
+            }
+            try {
+              if (elLoginError) elLoginError.textContent = "";
+              if (elLoginSubmit) fnSetBusyState(elLoginSubmit, true);
+              const res = await fetch(`${API_BASE}/login`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ username, password }),
+              });
+              let payload = null;
+              try {
+                payload = await res.json();
+              } catch (err) {
+                payload = null;
+              }
+              if (!res.ok || !payload?.token) {
+                throw new Error(
+                  payload?.error || "Invalid username or password.",
+                );
+              }
+              fnApplySession(payload.token, payload.user || null);
+              document.body.classList.add("authenticated");
+              if (elLoginPassword) elLoginPassword.value = "";
+              fnResetIdleTimer();
+              await fnAfterAuthenticated({ initial: !m_boolHasBootstrapped });
+            } catch (err) {
+              console.error("Login failed", err);
+              fnApplySession(null, null, { persist: false });
+              document.body.classList.remove("authenticated");
+              if (elLoginError) {
+                elLoginError.textContent =
+                  err?.message || "Unable to sign in. Please try again.";
+              }
+            } finally {
+              if (elLoginSubmit) fnSetBusyState(elLoginSubmit, false);
+            }
+          });
+        }
+
+        if (elLoginReset) {
+          elLoginReset.addEventListener("click", () => {
+            elLoginForm?.reset();
+            if (elLoginError) elLoginError.textContent = "";
+            window.localStorage.removeItem(SESSION_STORAGE_KEY);
+            elLoginUsername?.focus();
+          });
+        }
+
+        if (elLogoutButton) {
+          elLogoutButton.addEventListener("click", () => {
+            fnLogout();
+          });
+        }
+
+        ["pointerdown", "keydown", "touchstart"].forEach((evt) => {
+          document.addEventListener(
+            evt,
+            () => {
+              if (m_strSessionToken) {
+                fnResetIdleTimer();
+              }
+            },
+            { passive: true },
+          );
+        });
 
         /**
          * Mapping of business statuses to the visual pill classes we support.
@@ -3676,13 +4041,21 @@
               "Backend integration is disabled. Enable USE_BACKEND to load live data.",
             );
           }
+          const headers = {
+            "Content-Type": "application/json",
+            ...(opts.headers || {}),
+          };
+          if (m_strSessionToken && !headers.Authorization) {
+            headers.Authorization = `Bearer ${m_strSessionToken}`;
+          }
           const res = await fetch(API_BASE + path, {
             ...opts,
-            headers: {
-              "Content-Type": "application/json",
-              ...(opts.headers || {}),
-            },
+            headers,
           });
+          if (res.status === 401) {
+            await fnHandleUnauthorized();
+            throw new Error("Authentication required.");
+          }
           if (!res.ok) {
             let detail;
             try {
@@ -3692,6 +4065,7 @@
             }
             throw new Error(detail || `HTTP ${res.status}`);
           }
+          fnResetIdleTimer();
           return res;
         }
 
@@ -5048,41 +5422,74 @@
           );
         }
 
-        fnSetStatsLoading();
-        fnShowTableMessage("tbl-home-out", "Loading current checkouts…");
-        fnShowTableMessage("tbl-home-repairs", "Loading service tickets…");
-        fnShowTableMessage("tbl-borrow", "Loading recent loans…");
-        fnShowTableMessage("tbl-service", "Loading service tickets…");
-        fnShowTableMessage("tbl-admin-log", "Loading activity…");
-        if (USE_BACKEND) {
-          fnShowTableMessage(
-            "tbl-customer-profiles",
-            "Loading customer profiles…",
-          );
-          fnShowTableMessage("tbl-admin-users", "Loading user profiles…");
-          fnShowTableMessage("tbl-admin-inventory", "Loading inventory…");
-        } else {
-          fnShowTableMessage(
-            "tbl-customer-profiles",
-            "Enable backend to manage customer profiles.",
-          );
-          fnShowTableMessage(
-            "tbl-admin-users",
-            "Enable backend to load user profiles.",
-          );
-          fnShowTableMessage(
-            "tbl-admin-inventory",
-            "Enable backend to manage inventory items.",
-          );
+        async function fnAfterAuthenticated({ initial = false } = {}) {
+          document.body.classList.add("authenticated");
+          fnUpdateUserDisplay();
+          fnResetIdleTimer();
+
+          if (!m_boolHasBootstrapped) {
+            fnSetStatsLoading();
+            fnShowTableMessage("tbl-home-out", "Loading current checkouts…");
+            fnShowTableMessage(
+              "tbl-home-repairs",
+              "Loading service tickets…",
+            );
+            fnShowTableMessage("tbl-borrow", "Loading recent loans…");
+            fnShowTableMessage("tbl-service", "Loading service tickets…");
+            fnShowTableMessage("tbl-admin-log", "Loading activity…");
+            if (USE_BACKEND) {
+              fnShowTableMessage(
+                "tbl-customer-profiles",
+                "Loading customer profiles…",
+              );
+              fnShowTableMessage(
+                "tbl-admin-users",
+                "Loading user profiles…",
+              );
+              fnShowTableMessage(
+                "tbl-admin-inventory",
+                "Loading inventory…",
+              );
+            } else {
+              fnShowTableMessage(
+                "tbl-customer-profiles",
+                "Enable backend to manage customer profiles.",
+              );
+              fnShowTableMessage(
+                "tbl-admin-users",
+                "Enable backend to load user profiles.",
+              );
+              fnShowTableMessage(
+                "tbl-admin-inventory",
+                "Enable backend to manage inventory items.",
+              );
+            }
+            m_boolHasBootstrapped = true;
+          }
+
+          if (!USE_BACKEND) {
+            return;
+          }
+
+          fnLoadHomeData();
+          fnLoadBorrowingData();
+          fnLoadServiceData();
+          fnLoadAuditLog();
+          fnLoadInventoryData();
+          fnLoadAdminUsers();
+          fnEnsureCustomerProfilesLoaded();
         }
 
-        fnLoadHomeData();
-        fnLoadBorrowingData();
-        fnLoadServiceData();
-        fnLoadAuditLog();
-        fnLoadInventoryData();
-        fnLoadAdminUsers();
-        fnEnsureCustomerProfilesLoaded();
+        if (!USE_BACKEND) {
+          await fnAfterAuthenticated({ initial: true });
+        } else {
+          const restored = await fnRestoreSession();
+          if (restored) {
+            await fnAfterAuthenticated({ initial: true });
+          } else {
+            fnShowLogin();
+          }
+        }
 
         window.addEventListener("hashchange", () => {
           if (window.location.hash === "#admin-customers") {

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ The front-end now expects to communicate with a lightweight Node/Express API tha
 The Node server already contains the default SQL Server credentials (`sa` / `yourStrong(!)Password`) and points to `localhost:1433` with the `dbLabCenter` database. Update `server.js` directly if you need different connection details.
 
 The app serves both the API under `/api/*` and the static UI. Visit `http://localhost:3000/` after the server is running to see the dashboard populated with live data from SQL Server.
+
+## Authentication
+
+The UI now requires users to sign in before accessing any API endpoints. Use an existing lab tech username from the database with the default password `password123`. You can change credentials directly in SQL Server by updating the `dbo.TLabTechCredentials` table or by creating new users through the API and then updating their hashes manually.


### PR DESCRIPTION
## Summary
- add session middleware with login/logout/session endpoints and default credential seeding
- require authenticated lab tech IDs for tracked actions and update session cache when users change
- build a login UI with idle timeout handling and document the default password

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68e580f32d7483209c5782e8fa3152cc