### PR TITLE
Remove stray desktop.ini from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+desktop.ini

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,2 +1,0 @@
-[LocalizedFileNames]
-action_mark_green.avif=@action_mark_green.avif,0


### PR DESCRIPTION
## Summary
- delete the Windows-specific `desktop.ini` artifact from the repository
- ignore `desktop.ini` files going forward to prevent them from being committed again

## Testing
- not run (cleanup only)


------
https://chatgpt.com/codex/tasks/task_e_68e5d93fcd9c83209cc811fa5cff6a7b