### PR TITLE
Allow admins to update user passwords

### DIFF
--- a/LabCenterIMS.html
+++ b/LabCenterIMS.html
@@ -1860,6 +1860,20 @@
                 <option value="co-op">Co-Op</option>
               </select>
             </div>
+            <div class="full">
+              <label for="eu-password">New Password</label>
+              <input
+                id="eu-password"
+                type="password"
+                maxlength="255"
+                autocomplete="new-password"
+                placeholder="Leave blank to keep current password"
+              />
+              <p class="hint">
+                Leave blank to keep the current password. New passwords must be at
+                least 8 characters.
+              </p>
+            </div>
           </div>
         </div>
         <div class="modal-ft">
@@ -4524,6 +4538,10 @@
             );
             roleSelect.value = canonicalRole || "";
           }
+          const passwordInput = document.getElementById("eu-password");
+          if (passwordInput) {
+            passwordInput.value = "";
+          }
           dlg.showModal();
         }
 
@@ -5380,12 +5398,24 @@
                 fnSelectElement("#eu-username").value.trim();
               const display = fnSelectElement("#eu-display").value.trim();
               const role = fnSelectElement("#eu-role").value;
+              const passwordField = fnSelectElement("#eu-password");
+              const password = passwordField
+                ? passwordField.value.trim()
+                : "";
               fnMust(username && display && role, "All fields required.");
+              const payload = { display, role };
+              if (password) {
+                fnMust(password.length >= 8, "Password must be at least 8 characters.");
+                payload.password = password;
+              }
               await fnApi(`/users/${encodeURIComponent(username)}`, {
                 method: "PUT",
-                body: JSON.stringify({ display, role }),
+                body: JSON.stringify(payload),
               });
               fnCloseDialogById("dlg-edit-user");
+              if (passwordField) {
+                passwordField.value = "";
+              }
               alert("User updated.");
               await fnLoadAdminUsers({ showStatus: false });
             }),

--- a/server.js
+++ b/server.js
@@ -1961,11 +1961,20 @@ app.put('/api/users/:username', asyncHandler(async (req, res) => {
     return res.status(400).json({ error: 'Username required.' });
   }
 
-  const { display, role } = req.body || {};
+  const { display, role, password } = req.body || {};
   const displayName = normalizeString(display);
   const roleName = normalizeUserRole(role);
   if(!displayName || !roleName){
     return res.status(400).json({ error: 'Display and a valid role are required.' });
+  }
+
+  const normalizedPassword = typeof password === 'string' ? normalizeString(password) : '';
+  if(normalizedPassword && normalizedPassword.length < 8){
+    return res.status(400).json({ error: 'Password must be at least 8 characters.' });
+  }
+
+  if(normalizedPassword && normalizedPassword.length > 255){
+    return res.status(400).json({ error: 'Password must be 255 characters or fewer.' });
   }
 
   const cappedDisplayName = displayName.substring(0, 150);
@@ -1978,25 +1987,73 @@ app.put('/api/users/:username', asyncHandler(async (req, res) => {
   const pool = await getPool();
   await ensureUserTable(pool);
 
-  const result = await pool.request()
-    .input('Username', sql.VarChar(120), username)
-    .input('Display', sql.VarChar(150), cappedDisplayName)
-    .input('First', sql.VarChar(50), firstLimited)
-    .input('Last', sql.VarChar(50), lastLimited)
-    .input('Role', sql.VarChar(50), roleName)
-    .query(`
+  if(normalizedPassword){
+    await ensureUserCredentialTable(pool);
+  }
+
+  const transaction = new sql.Transaction(pool);
+  await transaction.begin();
+
+  try {
+    const updateRequest = new sql.Request(transaction);
+    updateRequest.input('Username', sql.VarChar(120), username);
+    updateRequest.input('Display', sql.VarChar(150), cappedDisplayName);
+    updateRequest.input('First', sql.VarChar(50), firstLimited);
+    updateRequest.input('Last', sql.VarChar(50), lastLimited);
+    updateRequest.input('Role', sql.VarChar(50), roleName);
+    if(normalizedPassword){
+      updateRequest.input('Password', sql.VarChar(255), normalizedPassword);
+    }
+
+    const passwordClause = normalizedPassword ? ",\n          strPassword = @Password" : '';
+
+    const updateSql = `
       UPDATE dbo.TLabTechs
       SET strDisplayName = @Display,
           strFirstName = @First,
           strLastName = @Last,
-          strRole = @Role
+          strRole = @Role${passwordClause}
       WHERE strUsername = @Username;
       SELECT @@ROWCOUNT AS updated;
-    `);
+    `;
 
-  const updated = result.recordset?.[0]?.updated ?? 0;
-  if(!updated){
-    return res.status(404).json({ error: 'User not found.' });
+    const result = await updateRequest.query(updateSql);
+    const updated = result.recordset?.[0]?.updated ?? 0;
+    if(!updated){
+      await transaction.rollback();
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    if(normalizedPassword){
+      const credentialRequest = new sql.Request(transaction);
+      credentialRequest.input('Username', sql.VarChar(120), username);
+      credentialRequest.input('Password', sql.VarChar(255), normalizedPassword);
+      await credentialRequest.query(`
+        DECLARE @UserId INT;
+        SELECT @UserId = intLabTechID
+        FROM dbo.TLabTechs
+        WHERE strUsername = @Username;
+
+        IF @UserId IS NOT NULL
+        BEGIN
+          MERGE dbo.TLabTechCredentials AS target
+          USING (SELECT @UserId AS intLabTechID) AS src
+          ON target.intLabTechID = src.intLabTechID
+          WHEN MATCHED THEN
+            UPDATE SET strPasswordHash = HASHBYTES('SHA2_256', @Password), dtmUpdated = SYSUTCDATETIME()
+          WHEN NOT MATCHED THEN
+            INSERT (intLabTechID, strPasswordHash)
+            VALUES (src.intLabTechID, HASHBYTES('SHA2_256', @Password));
+        END;
+      `);
+    }
+
+    await transaction.commit();
+  } catch(err){
+    try {
+      await transaction.rollback();
+    } catch { /* ignore */ }
+    throw err;
   }
 
   const detail = await pool.request()


### PR DESCRIPTION
## Summary
- add an optional password field to the admin user edit dialog and clear it when opened or saved
- send password changes from the UI when provided and enforce a minimum length before submitting
- update the user update API to accept password changes, validate length, and refresh stored password hashes inside a transaction

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68e5dfdccd4083208d548945325e3970