### PR TITLE
Remove item number field from inventory

### DIFF
--- a/LabCenterDatabase.sql
+++ b/LabCenterDatabase.sql
@@ -90,7 +90,6 @@ CREATE TABLE dbo.TItems
 (
     intItemID               INT IDENTITY(1,1) PRIMARY KEY,
     strItemName             VARCHAR(120) NOT NULL,
-    strItemNumber           VARCHAR(60)  NULL,
     blnIsSchoolOwned        BIT          NOT NULL,
     intDepartmentID         INT          NULL REFERENCES dbo.TDepartments(intDepartmentID),
     strDescription          VARCHAR(400) NULL,
@@ -100,8 +99,7 @@ CREATE TABLE dbo.TItems
     tDueTime                TIME(0)      NULL,
     dtmFixedDueLocal        DATETIME2(0) NULL,
     blnIsActive             BIT          NOT NULL CONSTRAINT DF_TItems_IsActive DEFAULT (1),
-    dtmCreated              DATETIME2(0) NOT NULL CONSTRAINT DF_TItems_Created  DEFAULT (SYSUTCDATETIME()),
-    CONSTRAINT UQ_TItems_ItemNumber UNIQUE (strItemNumber)
+    dtmCreated              DATETIME2(0) NOT NULL CONSTRAINT DF_TItems_Created  DEFAULT (SYSUTCDATETIME())
 );
 ALTER TABLE dbo.TItems ADD CONSTRAINT CK_TItems_DuePolicy CHECK (strDuePolicy IN ('NEXT_DAY_6PM','OFFSET','FIXED','SEMESTER'));
 CREATE INDEX IX_TItems_Name ON dbo.TItems(strItemName);
@@ -131,7 +129,6 @@ CREATE TABLE dbo.TItemLoans
     snapInstructor          VARCHAR(100) NULL,
 
     snapItemName            VARCHAR(120) NOT NULL,
-    snapItemNumber          VARCHAR(60)  NULL,
     snapIsSchoolOwned       BIT          NOT NULL,
     snapDepartmentName      VARCHAR(100) NULL,
 
@@ -232,7 +229,6 @@ AS
 SELECT
     it.intItemID,
     it.strItemName,
-    it.strItemNumber,
     it.blnIsSchoolOwned,
     d.strDepartmentName,
     il.intItemLoanID,
@@ -285,7 +281,7 @@ BEGIN
   SET NOCOUNT ON;
   INSERT dbo.TAuditLog (intLabTechID, strAction, strEntity, intEntityPK, strDetails)
   SELECT NULL, 'ITEM_CREATE', 'TItems', i.intItemID,
-         CONCAT('{"itemName":"', i.strItemName, '","itemNumber":"', ISNULL(i.strItemNumber,''), '","schoolOwned":', IIF(i.blnIsSchoolOwned=1,'true','false'), '}')
+         CONCAT('{"itemName":"', i.strItemName, '","schoolOwned":', IIF(i.blnIsSchoolOwned=1,'true','false'), '}')
   FROM inserted i;
 END
 GO
@@ -301,7 +297,7 @@ BEGIN
   -- Checkouts
   INSERT dbo.TAuditLog (intLabTechID, strAction, strEntity, intEntityPK, strDetails)
   SELECT il.intCheckoutLabTechID, 'CHECKOUT', 'TItemLoans', il.intItemLoanID,
-         CONCAT('{"item":"', il.snapItemName, '","itemNumber":"', ISNULL(il.snapItemNumber,''), '","borrower":"', il.snapBorrowerFirstName, ' ', il.snapBorrowerLastName,
+         CONCAT('{"item":"', il.snapItemName, '","borrower":"', il.snapBorrowerFirstName, ' ', il.snapBorrowerLastName,
                 '","checkoutUTC":"', CONVERT(varchar(19), il.dtmCheckoutUTC, 126), '","dueUTC":"', ISNULL(CONVERT(varchar(19), il.dtmDueUTC, 126), ''), '"}')
   FROM inserted il
   LEFT JOIN deleted d ON d.intItemLoanID = il.intItemLoanID
@@ -310,7 +306,7 @@ BEGIN
   -- Checkins
   INSERT dbo.TAuditLog (intLabTechID, strAction, strEntity, intEntityPK, strDetails)
   SELECT il.intCheckinLabTechID, 'CHECKIN', 'TItemLoans', il.intItemLoanID,
-         CONCAT('{"item":"', il.snapItemName, '","itemNumber":"', ISNULL(il.snapItemNumber,''), '","borrower":"', il.snapBorrowerFirstName, ' ', il.snapBorrowerLastName,
+         CONCAT('{"item":"', il.snapItemName, '","borrower":"', il.snapBorrowerFirstName, ' ', il.snapBorrowerLastName,
                 '","checkinUTC":"', CONVERT(varchar(19), il.dtmCheckinUTC, 126), '"}')
   FROM inserted il
   JOIN deleted  d ON d.intItemLoanID = il.intItemLoanID
@@ -448,7 +444,6 @@ IF OBJECT_ID('dbo.usp_CreateItem','P') IS NOT NULL DROP PROCEDURE dbo.usp_Create
 GO
 CREATE PROCEDURE dbo.usp_CreateItem
   @strItemName        VARCHAR(120),
-  @strItemNumber      VARCHAR(60) = NULL,
   @blnIsSchoolOwned   BIT,
   @intDepartmentID    INT = NULL,
   @strDescription     VARCHAR(400) = NULL,
@@ -475,7 +470,6 @@ BEGIN
   INSERT dbo.TItems
   (
     strItemName,
-    strItemNumber,
     blnIsSchoolOwned,
     intDepartmentID,
     strDescription,
@@ -488,7 +482,6 @@ BEGIN
   VALUES
   (
     @strItemName,
-    @strItemNumber,
     @blnIsSchoolOwned,
     @intDepartmentID,
     @strDescription,
@@ -548,12 +541,10 @@ BEGIN
   SET NOCOUNT ON;
 
   DECLARE @snapItemName VARCHAR(120),
-          @snapItemNumber VARCHAR(60),
           @snapIsSchoolOwned BIT,
           @snapDepartmentName VARCHAR(100);
 
   SELECT @snapItemName = strItemName,
-         @snapItemNumber = strItemNumber,
          @snapIsSchoolOwned = blnIsSchoolOwned,
          @snapDepartmentName = d.strDepartmentName
   FROM dbo.TItems i
@@ -585,13 +576,13 @@ BEGIN
   (
     intItemID,intBorrowerID,intCheckoutLabTechID,dtmDueUTC,strCheckoutNotes,
     snapBorrowerFirstName,snapBorrowerLastName,snapSchoolIDNumber,snapPhoneNumber,snapRoomNumber,snapInstructor,
-    snapItemName,snapItemNumber,snapIsSchoolOwned,snapDepartmentName
+    snapItemName,snapIsSchoolOwned,snapDepartmentName
   )
   VALUES
   (
     @intItemID,@intBorrowerID,@intCheckoutLabTechID,@dtmDueUTC,@strCheckoutNotes,
     @snapBorrowerFirstName,@snapBorrowerLastName,@snapSchoolIDNumber,@snapPhoneNumber,@snapRoomNumber,@snapInstructor,
-    @snapItemName,@snapItemNumber,@snapIsSchoolOwned,@snapDepartmentName
+    @snapItemName,@snapIsSchoolOwned,@snapDepartmentName
   );
 
   SELECT SCOPE_IDENTITY() AS intItemLoanID;
@@ -648,7 +639,6 @@ GO
 CREATE PROCEDURE dbo.usp_SaveItem
   @intItemID       INT = NULL,
   @strItemName     VARCHAR(120),
-  @strItemNumber   VARCHAR(60) = NULL,
   @blnIsSchoolOwned BIT,
   @intDepartmentID INT = NULL,
   @strDescription  VARCHAR(400) = NULL,
@@ -659,8 +649,8 @@ BEGIN
 
   IF @intItemID IS NULL
   BEGIN
-    INSERT dbo.TItems(strItemName,strItemNumber,blnIsSchoolOwned,intDepartmentID,strDescription,blnIsActive)
-    VALUES (@strItemName,@strItemNumber,@blnIsSchoolOwned,@intDepartmentID,@strDescription,@blnIsActive);
+    INSERT dbo.TItems(strItemName,blnIsSchoolOwned,intDepartmentID,strDescription,blnIsActive)
+    VALUES (@strItemName,@blnIsSchoolOwned,@intDepartmentID,@strDescription,@blnIsActive);
 
     SELECT SCOPE_IDENTITY() AS intItemID;
   END
@@ -668,7 +658,6 @@ BEGIN
   BEGIN
     UPDATE dbo.TItems
     SET strItemName = @strItemName,
-        strItemNumber = @strItemNumber,
         blnIsSchoolOwned = @blnIsSchoolOwned,
         intDepartmentID = @intDepartmentID,
         strDescription = @strDescription,
@@ -833,7 +822,6 @@ BEGIN
         il.snapSchoolIDNumber,
         il.snapRoomNumber,
         il.snapItemName,
-        il.snapItemNumber,
         il.snapDepartmentName,
         CASE
           WHEN il.dtmCheckinUTC IS NOT NULL THEN 'Returned'
@@ -851,8 +839,7 @@ BEGIN
       LoanCTE.snapBorrowerFirstName LIKE N'%' + @Search + N'%' OR
       LoanCTE.snapBorrowerLastName LIKE N'%' + @Search + N'%' OR
       LoanCTE.snapSchoolIDNumber LIKE N'%' + @Search + N'%' OR
-      LoanCTE.snapItemName LIKE N'%' + @Search + N'%' OR
-      LoanCTE.snapItemNumber LIKE N'%' + @Search + N'%'
+      LoanCTE.snapItemName LIKE N'%' + @Search + N'%'
     )
   ORDER BY LoanCTE.dtmCheckoutUTC DESC;
 END
@@ -948,14 +935,12 @@ BEGIN
   SELECT TOP (@Top)
       i.intItemID,
       i.strItemName,
-      i.strItemNumber,
       i.blnIsSchoolOwned,
       d.strDepartmentName,
       i.blnIsActive
   FROM dbo.TItems i
   LEFT JOIN dbo.TDepartments d ON d.intDepartmentID = i.intDepartmentID
   WHERE i.strItemName LIKE N'%' + @Search + N'%'
-     OR ISNULL(i.strItemNumber,N'') LIKE N'%' + @Search + N'%'
   ORDER BY i.strItemName;
 END
 GO

--- a/LabCenterIMS.html
+++ b/LabCenterIMS.html
@@ -1315,7 +1315,6 @@
                   <thead>
                     <tr>
                       <th scope="col">Item Name</th>
-                      <th scope="col">Item Number</th>
                       <th scope="col">Department</th>
                       <th scope="col">Due Policy</th>
                       <th scope="col">Actions</th>
@@ -1324,7 +1323,7 @@
                   <tbody id="tbl-admin-inventory">
                     <tr>
                       <td
-                        colspan="5"
+                        colspan="4"
                         style="
                           text-align: center;
                           color: var(--muted);
@@ -1807,10 +1806,6 @@
             <div class="full">
               <label>Item Name</label>
               <input id="mi-name" required />
-            </div>
-            <div>
-              <label>Item Number</label>
-              <input id="mi-number" placeholder="optional" />
             </div>
             <div>
               <label>Department</label>
@@ -3099,7 +3094,6 @@
             tr.classList.add("clickable");
             tr.dataset.itemId = item.id != null ? item.id : "";
             fnAppendTableCell(tr, item.name || "—");
-            fnAppendTableCell(tr, item.number || "—");
             fnAppendTableCell(tr, item.department || "—");
             fnAppendTableCell(tr, fnFormatItemDuePolicy(item));
             tbody.appendChild(tr);
@@ -3113,7 +3107,6 @@
           return entries.filter((item) => {
             const parts = [
               item.name,
-              item.number,
               item.department,
               item.duePolicy,
               item.duePolicyDescription,
@@ -3296,7 +3289,6 @@
           entries.forEach((item) => {
             const tr = document.createElement("tr");
             fnAppendTableCell(tr, item.name || "—");
-            fnAppendTableCell(tr, item.number || "—");
             fnAppendTableCell(tr, item.department || "—");
             fnAppendTableCell(tr, fnFormatItemDuePolicy(item));
             const actionCell = document.createElement("td");
@@ -3328,7 +3320,6 @@
           return entries.filter((item) => {
             const parts = [
               item.name,
-              item.number,
               item.department,
               item.duePolicy,
               item.duePolicyDescription,
@@ -4385,7 +4376,6 @@
           const borrower = obj.borrower || obj.customer || obj.customerName;
           if (item) {
             const parts = [item];
-            if (obj.itemNumber) parts[0] += ` (${obj.itemNumber})`;
             if (borrower) {
               let borrowerTxt = borrower;
               if (obj.schoolId || obj.schoolID || obj.schoolIdNumber) {
@@ -4614,8 +4604,6 @@
           if (idInput) idInput.value = item?.id ?? "";
           const nameInput = document.getElementById("mi-name");
           if (nameInput) nameInput.value = item?.name || "";
-          const numberInput = document.getElementById("mi-number");
-          if (numberInput) numberInput.value = item?.number || "";
           const deptInput = document.getElementById("mi-dept");
           if (deptInput) deptInput.value = item?.department || "";
           const ownedSelect = document.getElementById("mi-owned");
@@ -5378,7 +5366,6 @@
               fnMust(id, "Item identifier missing.");
               const name = fnSelectElement("#mi-name").value.trim();
               fnMust(name, "Item name required.");
-              const number = fnSelectElement("#mi-number").value.trim();
               const dept = fnSelectElement("#mi-dept").value.trim();
               const owned = fnSelectElement("#mi-owned").value !== "external";
               const description = fnSelectElement("#mi-description").value.trim();
@@ -5387,7 +5374,6 @@
 
               const payload = {
                 name,
-                number: number || null,
                 department: dept || null,
                 schoolOwned: owned,
                 description: description || null,


### PR DESCRIPTION
## Summary
- drop the strItemNumber column and related snapshots from the SQL schema and stored procedures
- update the API to stop reading or writing item numbers while keeping searches working by name only
- simplify the UI to remove item number inputs, columns, and filtering logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ee74ce0c8320902e189293f1cd7b