### PR TITLE
Refresh tables after status updates

### DIFF
--- a/LabCenterIMS.html
+++ b/LabCenterIMS.html
@@ -5117,6 +5117,15 @@
               body: JSON.stringify({ id, type, status, note }),
             });
 
+            const refreshTasks = [fnLoadHomeData()];
+            const kindForRefresh = fnMapTypeToKind(type);
+            if (kindForRefresh === "loan") {
+              refreshTasks.push(fnLoadBorrowingData());
+            } else if (kindForRefresh === "ticket") {
+              refreshTasks.push(fnLoadServiceData());
+            }
+            await Promise.allSettled(refreshTasks);
+
             // Update row status visually if present in current lists
             const row = document.querySelector(`[data-id="${CSS.escape(id)}"]`);
             if (row) {


### PR DESCRIPTION
## Summary
- trigger dashboard, loan, and service reloads after saving row edits
- ensure lists reflect returned items or completed tickets immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f2c73eb883209225642d53636a89