### PR TITLE
Remove deprecated statuses from service workflows

### DIFF
--- a/LabCenterDatabase.sql
+++ b/LabCenterDatabase.sql
@@ -169,7 +169,7 @@ CREATE TABLE dbo.TServiceTickets
     intAssignedLabTechID INT NULL REFERENCES dbo.TLabTechs(intLabTechID),
 
     strStatus           VARCHAR(30) NOT NULL CONSTRAINT DF_TServiceTickets_Status DEFAULT ('Diagnosing')
-       CHECK (strStatus IN ('Diagnosing','Awaiting Parts','Ready for Pickup','Quarantined','Completed','Cancelled'))
+      CHECK (strStatus IN ('Diagnosing','Awaiting Parts','Ready for Pickup','Completed','Cancelled'))
 );
 CREATE INDEX IX_TServiceTickets_Status ON dbo.TServiceTickets(strStatus, dtmLoggedUTC DESC);
 CREATE INDEX IX_TServiceTickets_Assigned ON dbo.TServiceTickets(intAssignedLabTechID, strStatus);
@@ -802,7 +802,7 @@ BEGIN
   SELECT
       outNow   = COALESCE(SUM(CASE WHEN dtmCheckinUTC IS NULL THEN 1 ELSE 0 END),0),
       dueToday = COALESCE(SUM(CASE WHEN dtmCheckinUTC IS NULL AND dtmDueUTC >= @startOfDay AND dtmDueUTC < @endOfDay THEN 1 ELSE 0 END),0),
-      repairs  = (SELECT COUNT(*) FROM dbo.TServiceTickets WHERE strStatus IN ('Diagnosing','Awaiting Parts','Ready for Pickup','Quarantined')),
+      repairs  = (SELECT COUNT(*) FROM dbo.TServiceTickets WHERE strStatus IN ('Diagnosing','Awaiting Parts','Ready for Pickup')),
       overdue  = COALESCE(SUM(CASE WHEN dtmCheckinUTC IS NULL AND dtmDueUTC IS NOT NULL AND dtmDueUTC < SYSUTCDATETIME() THEN 1 ELSE 0 END),0)
   FROM dbo.TItemLoans;
 END

--- a/LabCenterIMS.html
+++ b/LabCenterIMS.html
@@ -1684,15 +1684,7 @@
             </div>
             <div class="full">
               <label>Status</label>
-              <select id="det-status">
-                <option>On Time</option>
-                <option>Overdue</option>
-                <option>Returned</option>
-                <option>Diagnosing</option>
-                <option>Awaiting Parts</option>
-                <option>Ready for Pickup</option>
-                <option>Quarantined</option>
-              </select>
+              <select id="det-status"></select>
             </div>
             <div class="full">
               <label>Add Note</label>
@@ -2294,7 +2286,6 @@
           "Awaiting Parts": "repair",
           Diagnosing: "diagnosing",
           "Ready for Pickup": "ready",
-          Quarantined: "quarantine",
         };
 
         /**
@@ -2307,6 +2298,10 @@
           "Awaiting Parts": "is-awaiting",
           Diagnosing: "is-diagnosing",
           "Ready for Pickup": "is-ready",
+        };
+        const DETAIL_STATUS_OPTIONS = {
+          loan: ["On Time", "Overdue", "Returned"],
+          ticket: ["Diagnosing", "Awaiting Parts", "Ready for Pickup", "Returned"],
         };
         const ROW_STATUS_CLASSNAMES = Object.values(STATUS_ROW_CLASS_MAP);
 
@@ -2725,6 +2720,30 @@
         }
 
         // ====== TABLE ROW → DETAILS ======
+        function fnConfigureDetailStatusSelect(selectEl, kind, currentStatus) {
+          const options = DETAIL_STATUS_OPTIONS[kind] || [];
+          selectEl.innerHTML = "";
+          options.forEach((text) => {
+            const option = document.createElement("option");
+            option.value = text;
+            option.textContent = text;
+            selectEl.appendChild(option);
+          });
+          if (currentStatus && !options.includes(currentStatus)) {
+            const fallback = document.createElement("option");
+            fallback.value = currentStatus;
+            fallback.textContent = currentStatus;
+            selectEl.appendChild(fallback);
+          }
+          if (currentStatus) {
+            selectEl.value = currentStatus;
+          } else if (options.length) {
+            selectEl.value = options[0];
+          } else {
+            selectEl.value = "";
+          }
+        }
+
         const openDetail = (kind, id, primary, status) => {
           const dlg = document.getElementById("dlg-detail");
           fnSelectElement("#det-title").textContent =
@@ -2734,9 +2753,7 @@
           fnSelectElement("#det-id").value = id;
           fnSelectElement("#det-primary").value = primary || "";
           const sel = fnSelectElement("#det-status");
-          Array.from(sel.options).forEach((o) => {
-            if (o.text === status) sel.value = o.text;
-          });
+          fnConfigureDetailStatusSelect(sel, kind, status);
           fnSelectElement("#det-note").value = "";
           fnLoadDetailNotes(kind, id);
           dlg.showModal();
@@ -2758,7 +2775,11 @@
                 ? `${cells[1]} — ${cells[0]}`
                 : `${cells[1]} — ${cells[0]}`;
             const pill = tr.querySelector(".pill");
-            const status = pill ? pill.textContent.trim() : "On Time";
+            const status = pill
+              ? pill.textContent.trim()
+              : kind === "loan"
+              ? "On Time"
+              : "";
             openDetail(kind, id, primary, status);
           });
         }

--- a/server.js
+++ b/server.js
@@ -1791,7 +1791,7 @@ app.delete('/api/items/:id', asyncHandler(async (req, res) => {
 }));
 
 const LOAN_STATUS_SET = new Set(['On Time', 'Overdue', 'Returned']);
-const TICKET_STATUS_SET = new Set(['Diagnosing', 'Awaiting Parts', 'Ready for Pickup', 'Quarantined', 'Returned']);
+const TICKET_STATUS_SET = new Set(['Diagnosing', 'Awaiting Parts', 'Ready for Pickup', 'Returned']);
 
 app.post('/api/status', asyncHandler(async (req, res) => {
   const { id, type, status, note } = req.body || {};


### PR DESCRIPTION
## Summary
- update the detail dialog to only show loan statuses for loans and repair statuses for service tickets
- remove the Quarantined status from UI styling, API validation, and database constraints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5f25cc0288320b9612336923eb858